### PR TITLE
chore: update GitHub Action pins

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -205,7 +205,7 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --packages=.dart_tool/package_config.json --report-on=lib
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@ca0a928a4cb3911011e868128a5cd90437c12db1
         with:
           files: dart/coverage/lcov.info
           flags: dart-tests

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -171,7 +171,7 @@ jobs:
   general:
     permissions:
       contents: read
-    uses: famedly/frontend-ci-templates/.github/workflows/general.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/general.yml@e8167567258899ed2a5bcc7fe04c79ad78f87967
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: famedly/frontend-ci-templates/.github/workflows/publish-pub.yml@main
+    uses: famedly/frontend-ci-templates/.github/workflows/publish-pub.yml@e8167567258899ed2a5bcc7fe04c79ad78f87967
     with:
       env_file: ".github/workflows/versions.env"
 


### PR DESCRIPTION
## Summary
- Update GitHub Actions in workflows to the latest upstream default-branch commit SHAs.
- Keep existing action paths and only replace refs after `@`.

## Verification
- Checked generated diff to include only `.github/**/*.yml` / `.github/**/*.yaml` workflow action refs.
- CI on this PR should validate the updated action versions.