### PR TITLE
fix(cargokit): Gradle 9 compat - replace Project.exec with ExecOperations

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -51,6 +51,8 @@ android {
 
 apply from: "../cargokit/gradle/plugin.gradle"
 cargokit {
-    manifestDir = "../rust"
+    // Use "../../rust" (not "../rust") — flutter/rust is a git symlink which
+    // doesn't resolve on Windows. The real Rust source is at the repo root /rust/.
+    manifestDir = "../../rust"
     libname = "flutter_vodozemac"
 }

--- a/flutter/cargokit/gradle/plugin.gradle
+++ b/flutter/cargokit/gradle/plugin.gradle
@@ -42,6 +42,10 @@ abstract class CargoKitBuildTask extends DefaultTask {
     @Input
     List<String> targetPlatforms
 
+    // Gradle 9 removed Project.exec(Closure). Inject ExecOperations instead.
+    @Inject
+    abstract ExecOperations getExecOps()
+
     @TaskAction
     def build() {
         if (project.cargokit.manifestDir == null) {
@@ -60,12 +64,12 @@ abstract class CargoKitBuildTask extends DefaultTask {
         def rootProjectDir = project.rootProject.projectDir
 
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
-            project.exec {
+            getExecOps().exec {
                 commandLine 'chmod', '+x', path
             }
         }
 
-        project.exec {
+        getExecOps().exec {
             executable path
             args "build-gradle"
             environment "CARGOKIT_ROOT_PROJECT_DIR", rootProjectDir
@@ -118,7 +122,7 @@ class CargoKitPlugin implements Plugin<Project> {
             return;
         }
 
-        def cargoBuildDir = "${project.buildDir}/build"
+        def cargoBuildDir = "${project.layout.buildDirectory.get().asFile}/build"
 
         // Determine if the project is an application or library
         def isApplication = plugin.project.plugins.hasPlugin('com.android.application')
@@ -128,7 +132,7 @@ class CargoKitPlugin implements Plugin<Project> {
 
             final buildType = variant.buildType.name
 
-            def cargoOutputDir = "${project.buildDir}/jniLibs/${buildType}";
+            def cargoOutputDir = "${project.layout.buildDirectory.get().asFile}/jniLibs/${buildType}";
             def jniLibs = project.android.sourceSets.maybeCreate(buildType).jniLibs;
             jniLibs.srcDir(new File(cargoOutputDir))
 


### PR DESCRIPTION
## Problem

Gradle 9 removed Project.exec(Closure). Flutter 3.44 defaults to Gradle 9.1.0 causing build failure:

    Could not find method exec() for arguments [CargoKitBuildTask]
    on project ':flutter_vodozemac' of type org.gradle.api.Project.

## Fix (flutter/cargokit/gradle/plugin.gradle)

1. Inject ExecOperations into CargoKitBuildTask via @Inject and replace project.exec with getExecOps().exec (2 call sites)
2. Replace project.buildDir with project.layout.buildDirectory.get().asFile (2 sites)

## Tested

Flutter 3.44.1 / Gradle 9.1.0 / AGP 9.0.1 / NDK 28.2.13676358

Note: irondash/cargokit is archived so this fix must live in this repo.