### PR TITLE
fix: declare test_core as the dev dependency it is

### DIFF
--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 dependencies:
   collection: ^1.19.0
   flutter_rust_bridge: 2.11.1
-  test_core: ^0.6.8
   web: ^1.1.1
 
 dev_dependencies:
   dart_code_linter: any
   lints: ^5.1.1
   test: ^1.21.0
+  test_core: ^0.6.8
   checks: ^0.3.0
   import_sorter: ^4.6.0
   ffigen: ^18.1.0


### PR DESCRIPTION
`test_core` sits in `dependencies`, but the only thing that imports it is `dart/test/vodozemac_test_web.dart`, which reaches into `package:test_core/src/...` to run the suite inside a browser. That is a test concern.

As a regular dependency it joins the graph of every application that uses vodozemac, where a test runner gets a say in which `analyzer` version they are allowed to resolve — `test_core` follows the `test_api` the Flutter SDK pins and
caps `analyzer` from there. It also shows up in their license reports and SBOMs as something they ship to users, which they do not.

## Test plan

- `dart pub get`: `test_core` resolves as `direct dev`, so the web test still finds it
- `dart analyze`: same six pre-existing errors in `test/web_test_helper/` as on `main`, none new
